### PR TITLE
refactor: enforce Options API in remaining components

### DIFF
--- a/components/ContactSection.vue
+++ b/components/ContactSection.vue
@@ -23,20 +23,30 @@ section#kontakt.section
       p.status(role="status" aria-live="polite") {{ status }}
 </template>
 
-<script setup lang="ts">
-const form = reactive({ name: '', email: '', msg: '' })
-const errors = reactive({ name: '', email: '', msg: '' })
-const status = ref('')
+<script lang="ts">
+import { defineComponent } from 'vue'
 
-const onSubmit = () => {
-  errors.name = form.name ? '' : 'Bitte Namen eingeben.'
-  errors.email = /^\S+@\S+\.\S+$/.test(form.email) ? '' : 'Bitte gültige E-Mail eingeben.'
-  errors.msg = form.msg.length >= 10 ? '' : 'Bitte Ziel in mindestens 10 Zeichen beschreiben.'
+export default defineComponent({
+  name: 'ContactSection',
+  data() {
+    return {
+      form: { name: '', email: '', msg: '' },
+      errors: { name: '', email: '', msg: '' },
+      status: ''
+    }
+  },
+  methods: {
+    onSubmit() {
+      this.errors.name = this.form.name ? '' : 'Bitte Namen eingeben.'
+      this.errors.email = /^\S+@\S+\.\S+$/.test(this.form.email) ? '' : 'Bitte gültige E-Mail eingeben.'
+      this.errors.msg = this.form.msg.length >= 10 ? '' : 'Bitte Ziel in mindestens 10 Zeichen beschreiben.'
 
-  if (!errors.name && !errors.email && !errors.msg) {
-    status.value = 'Danke! Der Prototyp hat die Anfrage lokal validiert.'
-  } else {
-    status.value = 'Bitte korrigiere die markierten Felder.'
+      if (!this.errors.name && !this.errors.email && !this.errors.msg) {
+        this.status = 'Danke! Der Prototyp hat die Anfrage lokal validiert.'
+      } else {
+        this.status = 'Bitte korrigiere die markierten Felder.'
+      }
+    }
   }
-}
+})
 </script>

--- a/components/PrototypeCarousel.vue
+++ b/components/PrototypeCarousel.vue
@@ -123,13 +123,11 @@ section.proto(:class="themeClass" :data-theme="theme" role="region" :aria-label=
       a.nav-item.nav-link(href="/impressum" target="_blank" rel="noopener noreferrer" :title="t.legal.imprint" :aria-label="t.legal.imprint") {{ t.legal.imprint }}
 </template>
 
-<script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+<script lang="ts">
+import { defineComponent } from 'vue'
 
 type Locale = 'de' | 'en'
 type ThemeMode = 'light' | 'dark'
-const locale = ref<Locale>('de')
-const theme = ref<ThemeMode>('dark')
 
 const copy = {
   de: {
@@ -290,126 +288,138 @@ const copy = {
   }
 } as const
 
-const t = computed(() => copy[locale.value])
-const pages = computed(() => t.value.pages)
-const themeClass = computed(() => (theme.value === 'light' ? 'theme-light' : 'theme-dark'))
-
-const activeIndex = ref(0)
-const rotationStepCount = ref(0)
-const rotationDirection = ref<1 | -1>(1)
-const isPaused = ref(false)
-const contactEmail = 'tratschitt.m@icloud.com'
-const contactForm = ref({ firstName: '', lastName: '', email: '', subject: '' })
-let timer: ReturnType<typeof setInterval> | null = null
-
-const step = computed(() => 360 / 7)
-const radius = 1280
-
-const ringStyle = computed(() => ({
-  transform: `translateZ(-${radius}px) rotateY(${-rotationStepCount.value * step.value}deg)`
-}))
-
-const normalizedDelta = (idx: number) => {
-  const len = pages.value.length
-  let d = idx - activeIndex.value
-  if (d > len / 2) d -= len
-  if (d < -len / 2) d += len
-  return d
-}
-
-const cardStyle = (idx: number) => {
-  const d = normalizedDelta(idx)
-  const abs = Math.abs(d)
-  const hidden = abs > 2
-  return {
-    transform: `rotateY(${idx * step.value}deg) translateZ(${radius}px)`,
-    opacity: hidden ? '0' : d === 0 ? '1' : abs === 1 ? '.78' : '.42',
-    pointerEvents: hidden ? 'none' : 'auto',
-    zIndex: String(100 - abs)
-  }
-}
-
-const cardClass = (idx: number) => ({
-  'is-active': idx === activeIndex.value,
-  'is-hidden': Math.abs(normalizedDelta(idx)) > 2
-})
-
-const goTo = (index: number) => {
-  const len = pages.value.length
-  const target = (index + len) % len
-  if (target === activeIndex.value) return
-
-  if (rotationDirection.value === 1) {
-    const steps = (target - activeIndex.value + len) % len
-    rotationStepCount.value += steps
-  } else {
-    const steps = (activeIndex.value - target + len) % len
-    rotationStepCount.value -= steps
-  }
-  activeIndex.value = target
-}
-
-const rotateOne = (direction: 1 | -1) => {
-  const len = pages.value.length
-  activeIndex.value = (activeIndex.value + direction + len) % len
-  rotationStepCount.value += direction
-}
-
-const prev = () => {
-  rotationDirection.value = 1
-  rotateOne(1)
-}
-
-const next = () => {
-  rotationDirection.value = -1
-  rotateOne(-1)
-}
-
-const setLocale = (value: Locale) => {
-  locale.value = value
-}
-
-const setTheme = (value: ThemeMode) => {
-  theme.value = value
-}
-
-const openMailClient = () => {
-  const firstName = contactForm.value.firstName || '-'
-  const lastName = contactForm.value.lastName || '-'
-  const email = contactForm.value.email || '-'
-  const subject = contactForm.value.subject || (locale.value === 'de' ? 'Projektanfrage' : 'Project request')
-  const body = locale.value === 'de'
-    ? `Vorname: ${firstName}\nName: ${lastName}\nE-Mail: ${email}\n\nHallo Markus,\n`
-    : `First name: ${firstName}\nLast name: ${lastName}\nEmail: ${email}\n\nHi Markus,\n`
-  window.location.href = `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
-}
-
-watch(locale, () => {
-  activeIndex.value = 0
-  rotationStepCount.value = 0
-  rotationDirection.value = 1
-})
-
-useHead(() => ({
-  htmlAttrs: { lang: locale.value },
-  title: t.value.seoTitle,
-  meta: [{ name: 'description', content: t.value.seoDesc }]
-}))
-
-onMounted(() => {
-  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  if (reduceMotion) {
-    isPaused.value = true
-    return
-  }
-  timer = setInterval(() => {
-    if (!isPaused.value) {
-      rotateOne(rotationDirection.value)
+export default defineComponent({
+  name: 'PrototypeCarousel',
+  data() {
+    return {
+      locale: 'de' as Locale,
+      theme: 'dark' as ThemeMode,
+      activeIndex: 0,
+      rotationStepCount: 0,
+      rotationDirection: 1 as 1 | -1,
+      isPaused: false,
+      contactEmail: 'tratschitt.m@icloud.com',
+      contactForm: { firstName: '', lastName: '', email: '', subject: '' },
+      timer: null as ReturnType<typeof setInterval> | null,
+      radius: 1280
     }
-  }, 3200)
-})
+  },
+  computed: {
+    t() {
+      return copy[this.locale]
+    },
+    pages() {
+      return this.t.pages
+    },
+    themeClass() {
+      return this.theme === 'light' ? 'theme-light' : 'theme-dark'
+    },
+    step() {
+      return 360 / 7
+    },
+    ringStyle() {
+      return {
+        transform: `translateZ(-${this.radius}px) rotateY(${-this.rotationStepCount * this.step}deg)`
+      }
+    }
+  },
+  watch: {
+    locale() {
+      this.activeIndex = 0
+      this.rotationStepCount = 0
+      this.rotationDirection = 1
+    }
+  },
+  created() {
+    useHead(() => ({
+      htmlAttrs: { lang: this.locale },
+      title: this.t.seoTitle,
+      meta: [{ name: 'description', content: this.t.seoDesc }]
+    }))
+  },
+  mounted() {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduceMotion) {
+      this.isPaused = true
+      return
+    }
+    this.timer = setInterval(() => {
+      if (!this.isPaused) {
+        this.rotateOne(this.rotationDirection)
+      }
+    }, 3200)
+  },
+  beforeUnmount() {
+    if (this.timer) clearInterval(this.timer)
+  },
+  methods: {
+    normalizedDelta(idx: number) {
+      const len = this.pages.length
+      let d = idx - this.activeIndex
+      if (d > len / 2) d -= len
+      if (d < -len / 2) d += len
+      return d
+    },
+    cardStyle(idx: number) {
+      const d = this.normalizedDelta(idx)
+      const abs = Math.abs(d)
+      const hidden = abs > 2
+      return {
+        transform: `rotateY(${idx * this.step}deg) translateZ(${this.radius}px)`,
+        opacity: hidden ? '0' : d === 0 ? '1' : abs === 1 ? '.78' : '.42',
+        pointerEvents: hidden ? 'none' : 'auto',
+        zIndex: String(100 - abs)
+      }
+    },
+    cardClass(idx: number) {
+      return {
+        'is-active': idx === this.activeIndex,
+        'is-hidden': Math.abs(this.normalizedDelta(idx)) > 2
+      }
+    },
+    goTo(index: number) {
+      const len = this.pages.length
+      const target = (index + len) % len
+      if (target === this.activeIndex) return
 
-onUnmounted(() => {
-  if (timer) clearInterval(timer)
+      if (this.rotationDirection === 1) {
+        const steps = (target - this.activeIndex + len) % len
+        this.rotationStepCount += steps
+      } else {
+        const steps = (this.activeIndex - target + len) % len
+        this.rotationStepCount -= steps
+      }
+      this.activeIndex = target
+    },
+    rotateOne(direction: 1 | -1) {
+      const len = this.pages.length
+      this.activeIndex = (this.activeIndex + direction + len) % len
+      this.rotationStepCount += direction
+    },
+    prev() {
+      this.rotationDirection = 1
+      this.rotateOne(1)
+    },
+    next() {
+      this.rotationDirection = -1
+      this.rotateOne(-1)
+    },
+    setLocale(value: Locale) {
+      this.locale = value
+    },
+    setTheme(value: ThemeMode) {
+      this.theme = value
+    },
+    openMailClient() {
+      const firstName = this.contactForm.firstName || '-'
+      const lastName = this.contactForm.lastName || '-'
+      const email = this.contactForm.email || '-'
+      const subject = this.contactForm.subject || (this.locale === 'de' ? 'Projektanfrage' : 'Project request')
+      const body = this.locale === 'de'
+        ? `Vorname: ${firstName}\nName: ${lastName}\nE-Mail: ${email}\n\nHallo Markus,\n`
+        : `First name: ${firstName}\nLast name: ${lastName}\nEmail: ${email}\n\nHi Markus,\n`
+      window.location.href = `mailto:${this.contactEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+    }
+  }
 })
 </script>

--- a/components/ServicesSection.vue
+++ b/components/ServicesSection.vue
@@ -31,8 +31,8 @@ section#leistungen.section
         ) {{ item.short }}
 </template>
 
-<script setup lang="ts">
-import { computed, ref } from 'vue'
+<script lang="ts">
+import { defineComponent } from 'vue'
 
 const items = [
   {
@@ -57,16 +57,31 @@ const items = [
   }
 ]
 
-const activeIndex = ref(0)
-
-const trackStyle = computed(() => ({
-  transform: `translateX(-${activeIndex.value * 100}%)`
-}))
-
-const goTo = (index: number) => {
-  activeIndex.value = (index + items.length) % items.length
-}
-
-const prev = () => goTo(activeIndex.value - 1)
-const next = () => goTo(activeIndex.value + 1)
+export default defineComponent({
+  name: 'ServicesSection',
+  data() {
+    return {
+      items,
+      activeIndex: 0
+    }
+  },
+  computed: {
+    trackStyle() {
+      return {
+        transform: `translateX(-${this.activeIndex * 100}%)`
+      }
+    }
+  },
+  methods: {
+    goTo(index: number) {
+      this.activeIndex = (index + this.items.length) % this.items.length
+    },
+    prev() {
+      this.goTo(this.activeIndex - 1)
+    },
+    next() {
+      this.goTo(this.activeIndex + 1)
+    }
+  }
+})
 </script>


### PR DESCRIPTION
## Ziel
Options API ist verpflichtend. Diese PR ersetzt die letzten verbleibenden script-setup-Komponenten.

## Änderungen
- `components/PrototypeCarousel.vue`: von script setup auf `defineComponent` + `data/computed/methods/watch`
- `components/ServicesSection.vue`: auf klassische Options API umgestellt
- `components/ContactSection.vue`: auf klassische Options API umgestellt

## Ergebnis
- Keine `script setup`-Blöcke mehr in den relevanten UI-Komponenten.
- Funktionales Verhalten wurde beibehalten (Carousel, Locale/Theme, Formularvalidierung).
